### PR TITLE
add init func

### DIFF
--- a/console.go
+++ b/console.go
@@ -30,7 +30,14 @@ import (
 	"github.com/gopherjs/gopherjs/js"
 )
 
-var c = js.Global.Get("console")
+var c *js.Object
+
+//init check on exist js.Global
+func init() {
+	if js.Global != nil {
+		c = js.Global.Get("console")
+	}
+}
 
 // Assert writes msg to the console if b is false.
 func Assert(b bool, msg interface{}) {


### PR DESCRIPTION
add init func for check on exist js.Global

it is necessary for running\build go code how application not convert to js, in this case, console package crash with panic runtime error
